### PR TITLE
Handle empty numeric columns during imputation

### DIFF
--- a/run.py
+++ b/run.py
@@ -109,16 +109,23 @@ df = pd.read_csv(farm_path)
 # pprint.pprint(report)
 
 # Identify numeric columns
-numeric_cols = df.select_dtypes(include=['number']).columns
-df_numeric = df[numeric_cols]
+numeric_cols = df.select_dtypes(include=["number"]).columns
+df_processed = df[["time_stamp"]].copy()
 
-# Handle missing values using SimpleImputer
-imputer = SimpleImputer(strategy='mean')
-df_imputed_numeric = pd.DataFrame(imputer.fit_transform(df_numeric), columns=numeric_cols)
+if len(numeric_cols) > 0:
+    df_numeric = df[numeric_cols]
 
-# Re-add non-numeric columns (time_stamp and status_type_id_bool) to the imputed dataframe
-df_processed = df[['time_stamp']].copy()
-df_processed[numeric_cols] = df_imputed_numeric
+    # Handle missing values using SimpleImputer
+    imputer = SimpleImputer(strategy="mean")
+    df_imputed_numeric = pd.DataFrame(
+        imputer.fit_transform(df_numeric), columns=numeric_cols
+    )
+
+    # Re-add non-numeric columns (time_stamp and status_type_id_bool) to the imputed dataframe
+    df_processed[numeric_cols] = df_imputed_numeric
+else:
+    # If there are no numeric columns, simply keep the original non-numeric data
+    df_processed = df_processed.join(df.drop(columns=["time_stamp"]))
 
 # Create a temporary CSV file
 with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp_file:


### PR DESCRIPTION
## Summary
- guard the imputation step in `run.py` so it only executes when numeric columns are present
- retain the original non-numeric columns when no numeric data is available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4ce44b3148326a818fc1deb21bf6e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents failures when datasets contain no numeric columns by gracefully processing available data with time stamps.
  * Improves preprocessing stability to avoid crashes and inconsistent outputs in edge cases.
  * Ensures a consistent output structure whether or not numeric data is present, reducing the need for manual adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->