### PR TITLE
Guard preprocessing when time column missing

### DIFF
--- a/run.py
+++ b/run.py
@@ -109,16 +109,34 @@ df = pd.read_csv(farm_path)
 # pprint.pprint(report)
 
 # Identify numeric columns
-numeric_cols = df.select_dtypes(include=['number']).columns
-df_numeric = df[numeric_cols]
+numeric_cols = df.select_dtypes(include=["number"]).columns
+time_column = "time_stamp"
 
-# Handle missing values using SimpleImputer
-imputer = SimpleImputer(strategy='mean')
-df_imputed_numeric = pd.DataFrame(imputer.fit_transform(df_numeric), columns=numeric_cols)
+# Prepare processed dataframe, keeping the time column if it exists
+df_processed = pd.DataFrame(index=df.index)
+if time_column in df.columns:
+    df_processed[time_column] = df[time_column]
 
-# Re-add non-numeric columns (time_stamp and status_type_id_bool) to the imputed dataframe
-df_processed = df[['time_stamp']].copy()
-df_processed[numeric_cols] = df_imputed_numeric
+if len(numeric_cols) > 0:
+    df_numeric = df[numeric_cols]
+
+    # Handle missing values using SimpleImputer
+    imputer = SimpleImputer(strategy="mean")
+    df_imputed_numeric = pd.DataFrame(
+        imputer.fit_transform(df_numeric),
+        columns=numeric_cols,
+        index=df.index,
+    )
+
+    df_processed = df_processed.join(df_imputed_numeric)
+
+# Include remaining non-numeric columns (excluding the time column if present)
+non_numeric_cols = [col for col in df.columns if col not in numeric_cols]
+other_non_numeric_cols = [
+    col for col in non_numeric_cols if col != time_column
+]
+if other_non_numeric_cols:
+    df_processed = df_processed.join(df[other_non_numeric_cols])
 
 # Create a temporary CSV file
 with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp_file:


### PR DESCRIPTION
## Summary
- guard the preprocessing pipeline so it no longer errors when the `time_stamp` column is absent
- ensure remaining non-numeric columns are preserved alongside any imputed numeric data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4ce44b3148326a818fc1deb21bf6e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled automatic deletion of temporary CSV files after processing, preventing leftover files from accumulating.
  * Reduces disk usage and avoids clutter from previous runs, minimizing the risk of conflicts when re-running tasks.
  * Improves overall stability by ensuring temporary artifacts are cleaned up without manual intervention, leading to a more predictable storage footprint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->