### PR TITLE
Adjust prediction defaults for wind farm dataset

### DIFF
--- a/energy_fault_detector/quick_fault_detection/quick_fault_detector.py
+++ b/energy_fault_detector/quick_fault_detection/quick_fault_detector.py
@@ -24,7 +24,7 @@ setup_logging(os.path.join(os.path.dirname(__file__), '..', 'logging.yaml'))
 logger = logging.getLogger('energy_fault_detector')
 
 
-def quick_fault_detector(csv_data_path: str, csv_test_data_path: Optional[str] = None,
+def quick_fault_detector(csv_data_path: Optional[str], csv_test_data_path: Optional[str] = None,
                          train_test_column_name: Optional[str] = None, train_test_mapping: Optional[dict] = None,
                          time_column_name: Optional[str] = None, status_data_column_name: Optional[str] = None,
                          status_mapping: Optional[dict] = None,
@@ -50,9 +50,10 @@ def quick_fault_detector(csv_data_path: str, csv_test_data_path: Optional[str] =
     7. Visualization of output
 
     Args:
-        csv_data_path (str): Path to a csv-file containing tabular data which must contain training data for the
-            autoencoder. This data can also contain test data for evaluation, but in this case train_test_column and
-            optionally train_test_mapping must be provided.
+        csv_data_path (Optional[str]): Path to a csv-file containing tabular data which must contain training data for
+            the autoencoder. When running in prediction mode with a pre-trained model, this can be ``None`` to skip
+            loading training data. This data can also contain test data for evaluation, but in this case
+            ``train_test_column`` and optionally ``train_test_mapping`` must be provided.
         csv_test_data_path (Optional str): Path to a csv file containing test data for evaluation. If test data is
             provided in both ways (i.e. via csv_test_data_path and in csv_data_path + train_test_column) then both test
             data sets will be fused into one. Default is None.
@@ -124,6 +125,9 @@ def quick_fault_detector(csv_data_path: str, csv_test_data_path: Optional[str] =
 
     logger.info('Starting Automated Energy Fault Detection and Identification (mode=%s).', mode)
     logger.info('Loading Data...')
+    if csv_data_path is None and csv_test_data_path is None:
+        raise ValueError('At least one data source must be provided via `csv_data_path` or `csv_test_data_path`.')
+
     train_data, train_normal_index, test_data = load_train_test_data(csv_data_path=csv_data_path,
                                                                      csv_test_data_path=csv_test_data_path,
                                                                      train_test_column_name=train_test_column_name,

--- a/run_predict.py
+++ b/run_predict.py
@@ -28,6 +28,17 @@ from typing import Any, Dict, Optional
 from energy_fault_detector.quick_fault_detection import quick_fault_detector
 
 
+DEFAULT_MODEL_PATH = (
+    r"D:\Personal\Ideas\Wind turbine\CARE_To_Compare\CARE_To_Compare\Wind Farm B\models"
+    r"\asset_0\20251007_154309"
+)
+DEFAULT_PREDICT_DATA_PATH = (
+    r"D:\Personal\Ideas\Wind turbine\CARE_To_Compare\CARE_To_Compare\Wind Farm B\asset_files"
+    r"\predict_5.csv"
+)
+DEFAULT_TIME_COLUMN = "time_stamp"
+
+
 def _parse_mapping(value: Optional[str]) -> Optional[Dict[str, Any]]:
     """Parse a JSON dictionary supplied via the command line.
 
@@ -66,24 +77,34 @@ def build_argument_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--model-path",
-        required=True,
-        help="Path to the directory that contains the previously trained model.",
+        default=DEFAULT_MODEL_PATH,
+        help=(
+            "Path to the directory that contains the previously trained model. "
+            "Defaults to the predefined wind farm model when not supplied."
+        ),
     )
     parser.add_argument(
         "--csv-predict-data",
-        required=True,
-        help="CSV file that contains the data points to analyse for anomalies.",
+        default=DEFAULT_PREDICT_DATA_PATH,
+        help=(
+            "CSV file that contains the data points to analyse for anomalies. "
+            "Defaults to the provided wind farm dataset when not supplied."
+        ),
     )
     parser.add_argument(
         "--csv-train-data",
         help=(
-            "Optional CSV file that contains the training data. When omitted, the"
-            " prediction data is reused as a stand-in to satisfy the loader."
+            "Optional CSV file that contains the training data. When omitted, no "
+            "additional training is performed and the provided model is reused."
         ),
     )
     parser.add_argument(
         "--time-column",
-        help="Name of the timestamp column in the provided CSV files.",
+        default=DEFAULT_TIME_COLUMN,
+        help=(
+            "Name of the timestamp column in the provided CSV files. Defaults to "
+            "'time_stamp' for the predefined dataset."
+        ),
     )
     parser.add_argument(
         "--status-column",
@@ -156,7 +177,7 @@ def main() -> None:
         csv_train_data=args.csv_train_data,
     )
 
-    train_data_path = args.csv_train_data or args.csv_predict_data
+    train_data_path = args.csv_train_data
 
     prediction_results, event_metadata, _ = quick_fault_detector(
         csv_data_path=train_data_path,


### PR DESCRIPTION
## Summary
- default run_predict to the provided wind farm model directory, prediction CSV, and time column
- allow the quick fault detector to operate without training data when only prediction files are provided
- drop the `id` field during data loading so prediction uses only relevant sensor values

## Testing
- pytest *(fails: missing numpy/pandas in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f36dd2948326b28bd518a2a12aa1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional training data path with support for test-only runs.
  - Expanded configuration options (confidence threshold, feature exclusions, angle features, optimization toggle, debug plots, anomaly length, save directory, train/predict modes, model paths/names).
  - Predict CLI adds default model/data paths and a default time column.
- Changes
  - Requires at least one data source; predict flow no longer falls back to reuse predict data as training.
  - More consistent dataset alignment and ID column handling.
- Documentation
  - Updated parameter descriptions to reflect new options and behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->