### PR TITLE
Add configuration option to ignore ARCANA features

### DIFF
--- a/docs/config_example.yaml
+++ b/docs/config_example.yaml
@@ -63,4 +63,7 @@ root_cause_analysis:  # (optional) if not specified, no root_cause_analysis (ARC
   alpha: 0.8
   init_x_bias: recon
   num_iter: 200
+  ignore_features:
+    - windspeed
+    - output_power
 

--- a/docs/usage_examples.rst
+++ b/docs/usage_examples.rst
@@ -98,6 +98,10 @@ algorithm. An example:
 .. include:: config_example.yaml
    :literal:
 
+The optional ``ignore_features`` list inside ``root_cause_analysis`` can be used to prevent ARCANA from adjusting
+specific sensors (for example ``windspeed`` or ``output_power``). These features will be kept fixed during the
+optimisation and therefore won't be reported as a root cause.
+
 To update the configuration 'on the fly' (for example for hyperparameter optimization), you provide a new
 configuration dictionary via the ``update_config`` method:
 

--- a/energy_fault_detector/config/config.py
+++ b/energy_fault_detector/config/config.py
@@ -76,6 +76,11 @@ ROOT_CAUSE_ANALYSIS_SCHEMA = {
     'num_iter': {'type': 'integer', 'required': False},
     'epsilon': {'type': 'float', 'required': False},
     'verbose': {'type': 'boolean', 'required': False},
+    'ignore_features': {
+        'type': 'list',
+        'required': False,
+        'schema': {'type': 'string'},
+    },
 }
 
 PREDICT_SCHEMA = {

--- a/energy_fault_detector/root_cause_analysis/arcana.py
+++ b/energy_fault_detector/root_cause_analysis/arcana.py
@@ -2,7 +2,7 @@
 
 
 import logging
-from typing import Tuple, List
+from typing import Tuple, List, Optional, Set
 
 import numpy as np
 import pandas as pd
@@ -72,7 +72,7 @@ class Arcana:
 
     def __init__(self, model: AE_TYPE, learning_rate: float = 0.001, init_x_bias: str = 'recon',
                  alpha: float = 0.8, num_iter: int = 400, epsilon: float = 1e-8, verbose: bool = False,
-                 max_sample_threshold: int = 1000, **kwargs):
+                 max_sample_threshold: int = 1000, ignore_features: Optional[List[str]] = None, **kwargs):
 
         self.keras_model: AE_TYPE = model
 
@@ -89,6 +89,8 @@ class Arcana:
         self.num_iter: int = num_iter
         self.verbose: bool = verbose
         self.max_sample_threshold = max_sample_threshold
+        self.ignore_features: Set[str] = set(ignore_features or [])
+        self._feature_mask: Optional[tf.Tensor] = None
 
     def find_arcana_bias(self, x: pd.DataFrame, track_losses: bool = False, track_bias: bool = False
                          ) -> Tuple[pd.DataFrame, pd.DataFrame, List[pd.DataFrame]]:
@@ -111,6 +113,7 @@ class Arcana:
         """
 
         feature_names = x.columns
+        self._feature_mask = self._build_feature_mask(feature_names)
         timestamps = x.index
         x = x.values.astype('float32')
 
@@ -120,6 +123,7 @@ class Arcana:
 
         x_bias = self.initialize_x_bias(x)
         x_bias = tf.Variable(x_bias, dtype=tf.float32)
+        self._apply_feature_mask(x_bias)
         tracked_losses = {'Combined Loss': [], 'Reconstruction Loss': [], 'Regularization Loss': [], 'Iteration': []}
 
         bias = x_bias.numpy()
@@ -127,6 +131,7 @@ class Arcana:
         tracked_bias = [bias]
         for i in range(self.num_iter):
             x_bias, losses, _ = self.update_x_bias(x, x_bias)
+            self._apply_feature_mask(x_bias)
             if i % 50 == 0:
                 loss_1, loss_2, combined_loss = losses[0].numpy(), losses[1].numpy(), losses[2].numpy()
                 if track_losses:
@@ -141,11 +146,15 @@ class Arcana:
                     logger.info('%d Combined Loss: %.2f', i, combined_loss)
 
         x_bias = pd.DataFrame(data=x_bias.numpy(), columns=feature_names, index=timestamps)
+        self._apply_feature_mask_to_dataframe(x_bias)
 
         # return x_bias as a pandas DataFrame
         tracked_losses = pd.DataFrame(tracked_losses)
         tracked_losses = tracked_losses.set_index('Iteration')
         tracked_bias_dfs = [pd.DataFrame(data=bias, columns=feature_names, index=timestamps) for bias in tracked_bias]
+        for bias_df in tracked_bias_dfs:
+            self._apply_feature_mask_to_dataframe(bias_df)
+        self._feature_mask = None
         return x_bias, tracked_losses, tracked_bias_dfs
 
     def draw_samples(self, x: np.array) -> np.array:
@@ -215,5 +224,40 @@ class Arcana:
 
         # differentiate w.r.t. x_bias
         grad = grad_tape.gradient(loss_full, x_bias)
+        if self._feature_mask is not None:
+            grad = grad * self._feature_mask
         self.opt.apply_gradients(zip([grad], [x_bias]))
+        if self._feature_mask is not None:
+            x_bias.assign(x_bias * self._feature_mask)
         return x_bias, (loss_1, loss_2, loss_full), grad
+
+    def _build_feature_mask(self, feature_names: pd.Index) -> Optional[tf.Tensor]:
+        """Create mask to zero gradients for ignored features."""
+        if not self.ignore_features:
+            return None
+        mask = np.ones((1, len(feature_names)), dtype='float32')
+        for idx, name in enumerate(feature_names):
+            if name in self.ignore_features:
+                mask[0, idx] = 0.0
+        if np.all(mask == 1.0):
+            return None
+        ignored = sorted(set(feature_names).intersection(self.ignore_features))
+        if ignored:
+            logger.info('Ignoring %s feature(s) during ARCANA optimisation: %s', len(ignored), ', '.join(ignored))
+        not_found = self.ignore_features.difference(feature_names)
+        if not_found:
+            logger.warning('Configured features to ignore not found in input data: %s', ', '.join(sorted(not_found)))
+        return tf.constant(mask, dtype=tf.float32)
+
+    def _apply_feature_mask(self, x_bias: tf.Variable) -> None:
+        """Ensure ignored features remain unchanged."""
+        if self._feature_mask is not None:
+            x_bias.assign(x_bias * self._feature_mask)
+
+    def _apply_feature_mask_to_dataframe(self, df: pd.DataFrame) -> None:
+        """Zero-out ignored feature values in a DataFrame result."""
+        if not self.ignore_features:
+            return
+        intersection = self.ignore_features.intersection(df.columns)
+        if intersection:
+            df.loc[:, list(intersection)] = 0.0

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -46,7 +46,8 @@ class TestConfig(unittest.TestCase):
         self.assertDictEqual(conf.config_dict['root_cause_analysis'],
                              {'alpha': 0.8,
                               'init_x_bias': 'recon',
-                              'num_iter': 200}
+                              'num_iter': 200,
+                              'ignore_features': ['windspeed', 'output_power']}
                              )
 
     def test_arcana_config(self):
@@ -54,7 +55,8 @@ class TestConfig(unittest.TestCase):
         self.assertTrue(conf.root_cause_analysis)
         self.assertDictEqual(
             conf.arcana_params,
-            {'alpha': 0.8, 'num_iter': 200, 'init_x_bias': 'recon'}
+            {'alpha': 0.8, 'num_iter': 200, 'init_x_bias': 'recon',
+             'ignore_features': ['windspeed', 'output_power']}
         )
 
         conf = Config(os.path.join(PROJECT_ROOT, './tests/test_data/test_config_no_rca.yaml'))

--- a/tests/root_cause_analysis/test_arcana.py
+++ b/tests/root_cause_analysis/test_arcana.py
@@ -104,3 +104,12 @@ class TestArcana(TestCase):
         selection = arcana.draw_samples(x=self.data)
         self.assertTupleEqual(self.data[:-1].shape, self.data[selection].shape)
 
+    def test_ignore_features(self):
+        ignore_cols = [self.data_frame.columns[0], 'non_existing_feature']
+        arcana = Arcana(model=self.ml_ae, num_iter=5, ignore_features=ignore_cols)
+        subset = self.data_frame.iloc[:20]
+        bias, losses, _ = arcana.find_arcana_bias(subset, track_losses=True)
+        self.assertTrue((bias[ignore_cols[0]] == 0).all())
+        # ensure optimisation still runs and logs losses
+        self.assertFalse(losses.empty)
+

--- a/tests/test_data/test_config.yaml
+++ b/tests/test_data/test_config.yaml
@@ -40,3 +40,6 @@ root_cause_analysis:
   alpha: 0.8
   init_x_bias: recon
   num_iter: 200
+  ignore_features:
+    - windspeed
+    - output_power


### PR DESCRIPTION
## Summary
- extend the root cause analysis configuration schema with an `ignore_features` list
- keep the ARCANA optimiser from adjusting ignored sensors and zero their bias outputs
- document the new option and cover it with configuration and ARCANA unit tests

## Testing
- pytest tests/config/test_config.py tests/root_cause_analysis/test_arcana.py *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e604eea27c8326a7c0b4dc652b7d7b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional setting to ignore specific features during root-cause analysis. Ignored features won’t be adjusted in optimization and are excluded from reports. Configure via root_cause_analysis.ignore_features in the training config. Defaults to no ignored features.

- Documentation
  - Updated configuration examples and usage guidance to describe the ignore_features option and its effects.

- Tests
  - Added tests validating ignore behavior and updated test configurations accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->