### PR TITLE
Save prediction outputs by asset

### DIFF
--- a/run_predict.py
+++ b/run_predict.py
@@ -145,6 +145,13 @@ def build_argument_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Enable creation of additional debug plots during prediction.",
     )
+    parser.add_argument(
+        "--asset-name",
+        help=(
+            "Optional identifier for the analysed asset. When provided, prediction CSV files are "
+            "written to a 'prediction_output/<asset-name>' directory."
+        ),
+    )
     return parser
 
 
@@ -192,6 +199,7 @@ def main() -> None:
         enable_debug_plots=args.debug_plots,
         mode="predict",
         model_path=args.model_path,
+        asset_name=args.asset_name,
     )
 
     predicted_anomalies = prediction_results.predicted_anomalies


### PR DESCRIPTION
## Summary
- extend the quick fault detector to persist prediction artefacts in a prediction_output/<asset> folder when running in predict mode
- add an optional asset_name argument and CLI flag so callers can control the output folder name

## Testing
- pytest *(fails: missing optional dependencies such as numpy and pandas in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e685dd00e48326805ba7f55c839274