### PR TITLE
Add Docker stack setup scripts and compose configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Ignore files and directories not needed in Docker build contexts
+.git
+.gitignore
+.env
+.env.*
+.venv
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.swp
+.notebooks_cache/
+results/
+.mongodb/
+node_modules/
+web-service/node_modules/
+web-ui/node_modules/
+web-ui/dist/
+web-ui/.vite/
+docs/_build/
+web-ui/coverage/
+*.log

--- a/README.md
+++ b/README.md
@@ -79,6 +79,30 @@ quick_fault_detector <path_to_c2c_dataset.csv> --c2c_example
 For more information, have a look at the notebook [Quick Failure Detection](./notebooks/Example%20-%20Quick%20Failure%20Detection.ipynb)
 
 
+## Local Docker stack
+
+Spin up the full Energy Fault Detector demo environment (FastAPI services, Node proxy, React UI, and MongoDB) with a single command:
+
+```bash
+./scripts/setup_docker_local.sh
+```
+
+The script builds the Docker images, ensures data/log directories exist, and exposes the services on their default ports:
+
+- FastAPI sync API: http://localhost:8000
+- FastAPI async prediction API: http://localhost:8001
+- Node proxy service: http://localhost:4000
+- React UI: http://localhost:5173
+- MongoDB: mongodb://localhost:27017
+
+Customise container names, ports, and volume locations with the script's command-line options or environment variables. On Windows, run the PowerShell variant:
+
+```powershell
+./scripts/setup_docker_local.ps1
+```
+
+Pass additional arguments to `docker compose up` after `--` (Bash) or via `-ComposeArgs` (PowerShell). Stop the stack with `docker compose -p energy-fault-detector down`.
+
 ## REST prediction API
 
 The project ships with a lightweight FastAPI application that exposes the prediction workflow via HTTP. The service

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1.5
+
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       build-essential \
+       curl \
+       git \
+       libatlas-base-dev \
+       libblas-dev \
+       liblapack-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY pyproject.toml README.md ./
+COPY energy_fault_detector ./energy_fault_detector
+COPY run.py run_bulk_train.py run_predict.py ./
+COPY scripts ./scripts
+COPY asset_dataset_splitter.py ./
+COPY setup.py ./setup.py
+
+RUN pip install --no-cache-dir -e .
+
+RUN chmod +x scripts/start_services.sh
+
+EXPOSE 8000 8001
+
+CMD ["/bin/bash", "scripts/start_services.sh", "energy_fault_detector/api/service_config.yaml", "--host", "0.0.0.0"]

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -1,0 +1,84 @@
+version: "3.9"
+
+services:
+  mongodb:
+    image: mongo:7.0
+    container_name: ${MONGO_CONTAINER_NAME:-energy-fault-detector-mongo}
+    restart: unless-stopped
+    ports:
+      - "${MONGO_PORT:-27017}:27017"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME:-efd_root}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD:-efd_root_password}
+      MONGO_APP_DB: ${MONGO_APP_DB:-energy_fault_detector}
+      MONGO_APP_USER: ${MONGO_APP_USER:-efd_app}
+      MONGO_APP_PASSWORD: ${MONGO_APP_PASSWORD:-efd_app_password}
+    volumes:
+      - ${MONGO_DATA_DIR:-../.mongodb/data}:/data/db
+      - ${MONGO_LOG_DIR:-../.mongodb/logs}:/var/log/mongodb
+      - ./mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
+    healthcheck:
+      test: ["CMD-SHELL", "mongosh --quiet --eval 'db.adminCommand("ping")'"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  api:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.api
+    container_name: ${API_CONTAINER_NAME:-energy-fault-detector-api}
+    restart: unless-stopped
+    depends_on:
+      mongodb:
+        condition: service_healthy
+    environment:
+      API_HOST: ${API_HOST:-0.0.0.0}
+      API_PORT: ${API_PORT:-8000}
+      PREDICTION_API_HOST: ${PREDICTION_API_HOST:-0.0.0.0}
+      PREDICTION_API_PORT: ${PREDICTION_PORT:-8001}
+      EFD_SERVICE_CONFIG: ${API_SERVICE_CONFIG:-/app/energy_fault_detector/api/service_config.yaml}
+      EFD_RESULTS_DIR: ${EFD_RESULTS_DIR:-/app/results}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      PERPLEXITY_API_KEY: ${PERPLEXITY_API_KEY:-}
+    ports:
+      - "${API_PORT:-8000}:8000"
+      - "${PREDICTION_PORT:-8001}:8001"
+    volumes:
+      - ${HOST_RESULTS_DIR:-../results}:/app/results
+      - ${HOST_MODELS_DIR:-../models}:/app/models
+
+  web-service:
+    build:
+      context: ../web-service
+      dockerfile: Dockerfile
+    container_name: ${WEB_SERVICE_CONTAINER_NAME:-energy-fault-detector-web-service}
+    restart: unless-stopped
+    depends_on:
+      mongodb:
+        condition: service_healthy
+      api:
+        condition: service_started
+    environment:
+      PORT: ${WEB_SERVICE_PORT:-4000}
+      MONGO_URI: mongodb://${MONGO_APP_USER:-efd_app}:${MONGO_APP_PASSWORD:-efd_app_password}@mongodb:27017/${MONGO_APP_DB:-energy_fault_detector}?authSource=admin
+      MONGO_DB_NAME: ${MONGO_APP_DB:-energy_fault_detector}
+      DATASET_API_BASE_URL: http://api:8000
+      PREDICTION_API_BASE_URL: http://api:8001
+      CORS_ORIGIN: ${WEB_SERVICE_CORS_ORIGIN:-*}
+      SESSION_TTL_SECONDS: ${WEB_SERVICE_SESSION_TTL_SECONDS:-}
+    ports:
+      - "${WEB_SERVICE_PORT:-4000}:4000"
+
+  web-ui:
+    build:
+      context: ../web-ui
+    container_name: ${WEB_UI_CONTAINER_NAME:-energy-fault-detector-web-ui}
+    restart: unless-stopped
+    depends_on:
+      web-service:
+        condition: service_started
+    environment:
+      VITE_API_BASE_URL: ${WEB_UI_API_BASE_URL:-http://localhost:${WEB_SERVICE_PORT:-4000}}
+    ports:
+      - "${WEB_UI_PORT:-5173}:5173"

--- a/docker/mongo-init.js
+++ b/docker/mongo-init.js
@@ -1,0 +1,19 @@
+const appDbName = process.env.MONGO_APP_DB || 'energy_fault_detector';
+const appUser = process.env.MONGO_APP_USER || 'efd_app';
+const appPassword = process.env.MONGO_APP_PASSWORD || 'efd_app_password';
+
+const adminDb = db.getSiblingDB('admin');
+const targetDb = db.getSiblingDB(appDbName);
+
+if (!adminDb.getUser(appUser)) {
+  print(`Creating MongoDB application user ${appUser} for database ${appDbName}.`);
+  targetDb.createUser({
+    user: appUser,
+    pwd: appPassword,
+    roles: [
+      { role: 'readWrite', db: appDbName }
+    ]
+  });
+} else {
+  print(`MongoDB application user ${appUser} already exists; skipping creation.`);
+}

--- a/scripts/setup_docker_local.ps1
+++ b/scripts/setup_docker_local.ps1
@@ -1,0 +1,252 @@
+#!/usr/bin/env pwsh
+# Utility script to launch the Energy Fault Detector stack in Docker (PowerShell edition).
+
+param(
+    [switch]$Help,
+    [string]$ProjectName,
+    [string]$ComposeFile,
+    [string]$MongoContainerName,
+    [Nullable[int]]$MongoPort,
+    [string]$MongoDataDir,
+    [string]$MongoLogDir,
+    [string]$MongoRootUser,
+    [string]$MongoRootPassword,
+    [string]$MongoAppDb,
+    [string]$MongoAppUser,
+    [string]$MongoAppPassword,
+    [string]$ApiContainerName,
+    [Nullable[int]]$ApiPort,
+    [Nullable[int]]$PredictionPort,
+    [string]$ResultsDir,
+    [string]$ModelsDir,
+    [string]$WebServiceContainerName,
+    [Nullable[int]]$WebServicePort,
+    [string]$WebUiContainerName,
+    [Nullable[int]]$WebUiPort,
+    [string[]]$ComposeArgs
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Show-Usage {
+    @'
+Usage: ./scripts/setup_docker_local.ps1 [options]
+
+Bootstraps the Energy Fault Detector API, Node service, React UI, and MongoDB
+using Docker Compose. Extra docker compose arguments can be supplied via
+-ComposeArgs.
+
+Parameters (environment variables may also be used):
+  -Help                         Show this help message and exit
+  -ProjectName <name>           Docker Compose project name (default: energy-fault-detector)
+  -ComposeFile <path>           Path to the docker compose file (default: ./docker/docker-compose.local.yml)
+  -MongoContainerName <name>    MongoDB container name (default: energy-fault-detector-mongo)
+  -MongoPort <port>             Host port for MongoDB (default: 27017)
+  -MongoDataDir <path>          Directory for MongoDB data volume (default: ./.mongodb/data)
+  -MongoLogDir <path>           Directory for MongoDB logs (default: ./.mongodb/logs)
+  -MongoRootUser <user>         MongoDB root username (default: efd_root)
+  -MongoRootPassword <pass>     MongoDB root password (default: efd_root_password)
+  -MongoAppDb <name>            MongoDB application database (default: energy_fault_detector)
+  -MongoAppUser <user>          MongoDB application username (default: efd_app)
+  -MongoAppPassword <pass>      MongoDB application password (default: efd_app_password)
+  -ApiContainerName <name>      API container name (default: energy-fault-detector-api)
+  -ApiPort <port>               Host port for the synchronous FastAPI service (default: 8000)
+  -PredictionPort <port>        Host port for the asynchronous prediction API (default: 8001)
+  -ResultsDir <path>            Directory to persist API results (default: ./results)
+  -ModelsDir <path>             Directory containing trained models (default: ./models)
+  -WebServiceContainerName <name>  Node service container name (default: energy-fault-detector-web-service)
+  -WebServicePort <port>        Host port for the Node service (default: 4000)
+  -WebUiContainerName <name>    React UI container name (default: energy-fault-detector-web-ui)
+  -WebUiPort <port>             Host port for the React UI (default: 5173)
+  -ComposeArgs <array>          Additional arguments passed to 'docker compose up'
+
+Environment overrides:
+  EFD_COMPOSE_PROJECT, EFD_COMPOSE_FILE, MONGO_CONTAINER_NAME, MONGO_PORT,
+  MONGO_DATA_DIR, MONGO_LOG_DIR, MONGO_INITDB_ROOT_USERNAME, MONGO_INITDB_ROOT_PASSWORD,
+  MONGO_APP_DB, MONGO_APP_USER, MONGO_APP_PASSWORD, API_CONTAINER_NAME,
+  API_PORT, PREDICTION_PORT, HOST_RESULTS_DIR, HOST_MODELS_DIR,
+  WEB_SERVICE_CONTAINER_NAME, WEB_SERVICE_PORT,
+  WEB_UI_CONTAINER_NAME, WEB_UI_PORT
+'@
+}
+
+function Get-ConfigValue {
+    param(
+        [object]$ParameterValue,
+        [string]$EnvName,
+        [string]$DefaultValue
+    )
+
+    if ($null -ne $ParameterValue) {
+        $stringValue = [string]$ParameterValue
+        if (-not [string]::IsNullOrEmpty($stringValue)) {
+            return $stringValue
+        }
+    }
+
+    $envValue = [Environment]::GetEnvironmentVariable($EnvName)
+    if (-not [string]::IsNullOrEmpty($envValue)) {
+        return $envValue
+    }
+
+    return $DefaultValue
+}
+
+if ($Help) {
+    Show-Usage
+    exit 0
+}
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RootDir = Split-Path -Parent $ScriptDir
+
+$DefaultComposeFile = Join-Path -Path $RootDir -ChildPath 'docker'
+$DefaultComposeFile = Join-Path -Path $DefaultComposeFile -ChildPath 'docker-compose.local.yml'
+$DefaultMongoDataDir = Join-Path -Path $RootDir -ChildPath '.mongodb'
+$DefaultMongoDataDir = Join-Path -Path $DefaultMongoDataDir -ChildPath 'data'
+$DefaultMongoLogDir = Join-Path -Path $RootDir -ChildPath '.mongodb'
+$DefaultMongoLogDir = Join-Path -Path $DefaultMongoLogDir -ChildPath 'logs'
+$DefaultResultsDir = Join-Path -Path $RootDir -ChildPath 'results'
+$DefaultModelsDir = Join-Path -Path $RootDir -ChildPath 'models'
+
+$ProjectName = Get-ConfigValue -ParameterValue $ProjectName -EnvName 'EFD_COMPOSE_PROJECT' -DefaultValue 'energy-fault-detector'
+$ComposeFile = Get-ConfigValue -ParameterValue $ComposeFile -EnvName 'EFD_COMPOSE_FILE' -DefaultValue $DefaultComposeFile
+$MongoContainerName = Get-ConfigValue -ParameterValue $MongoContainerName -EnvName 'MONGO_CONTAINER_NAME' -DefaultValue 'energy-fault-detector-mongo'
+$MongoPort = [int](Get-ConfigValue -ParameterValue $MongoPort -EnvName 'MONGO_PORT' -DefaultValue '27017')
+$MongoDataDir = Get-ConfigValue -ParameterValue $MongoDataDir -EnvName 'MONGO_DATA_DIR' -DefaultValue $DefaultMongoDataDir
+$MongoLogDir = Get-ConfigValue -ParameterValue $MongoLogDir -EnvName 'MONGO_LOG_DIR' -DefaultValue $DefaultMongoLogDir
+${'$'}defaultRootUser = [Environment]::GetEnvironmentVariable('MONGO_INITDB_ROOT_USERNAME')
+if ([string]::IsNullOrEmpty(${ '$'}defaultRootUser)) {
+    ${'$'}defaultRootUser = [Environment]::GetEnvironmentVariable('MONGO_ROOT_USER')
+}
+if ([string]::IsNullOrEmpty(${ '$'}defaultRootUser)) {
+    ${'$'}defaultRootUser = 'efd_root'
+}
+${'$'}MongoRootUser = Get-ConfigValue -ParameterValue ${'$'}MongoRootUser -EnvName 'MONGO_INITDB_ROOT_USERNAME' -DefaultValue ${'$'}defaultRootUser
+${'$'}defaultRootPassword = [Environment]::GetEnvironmentVariable('MONGO_INITDB_ROOT_PASSWORD')
+if ([string]::IsNullOrEmpty(${ '$'}defaultRootPassword)) {
+    ${'$'}defaultRootPassword = [Environment]::GetEnvironmentVariable('MONGO_ROOT_PASSWORD')
+}
+if ([string]::IsNullOrEmpty(${ '$'}defaultRootPassword)) {
+    ${'$'}defaultRootPassword = 'efd_root_password'
+}
+${'$'}MongoRootPassword = Get-ConfigValue -ParameterValue ${'$'}MongoRootPassword -EnvName 'MONGO_INITDB_ROOT_PASSWORD' -DefaultValue ${'$'}defaultRootPassword
+$MongoAppDb = Get-ConfigValue -ParameterValue $MongoAppDb -EnvName 'MONGO_APP_DB' -DefaultValue 'energy_fault_detector'
+$MongoAppUser = Get-ConfigValue -ParameterValue $MongoAppUser -EnvName 'MONGO_APP_USER' -DefaultValue 'efd_app'
+$MongoAppPassword = Get-ConfigValue -ParameterValue $MongoAppPassword -EnvName 'MONGO_APP_PASSWORD' -DefaultValue 'efd_app_password'
+$ApiContainerName = Get-ConfigValue -ParameterValue $ApiContainerName -EnvName 'API_CONTAINER_NAME' -DefaultValue 'energy-fault-detector-api'
+$ApiPort = [int](Get-ConfigValue -ParameterValue $ApiPort -EnvName 'API_PORT' -DefaultValue '8000')
+$PredictionPort = [int](Get-ConfigValue -ParameterValue $PredictionPort -EnvName 'PREDICTION_PORT' -DefaultValue '8001')
+$ResultsDir = Get-ConfigValue -ParameterValue $ResultsDir -EnvName 'HOST_RESULTS_DIR' -DefaultValue $DefaultResultsDir
+$ModelsDir = Get-ConfigValue -ParameterValue $ModelsDir -EnvName 'HOST_MODELS_DIR' -DefaultValue $DefaultModelsDir
+$WebServiceContainerName = Get-ConfigValue -ParameterValue $WebServiceContainerName -EnvName 'WEB_SERVICE_CONTAINER_NAME' -DefaultValue 'energy-fault-detector-web-service'
+$WebServicePort = [int](Get-ConfigValue -ParameterValue $WebServicePort -EnvName 'WEB_SERVICE_PORT' -DefaultValue '4000')
+$WebUiContainerName = Get-ConfigValue -ParameterValue $WebUiContainerName -EnvName 'WEB_UI_CONTAINER_NAME' -DefaultValue 'energy-fault-detector-web-ui'
+$WebUiPort = [int](Get-ConfigValue -ParameterValue $WebUiPort -EnvName 'WEB_UI_PORT' -DefaultValue '5173')
+
+$ComposeFile = [System.IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($ComposeFile))
+$MongoDataDir = [System.IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($MongoDataDir))
+$MongoLogDir = [System.IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($MongoLogDir))
+$ResultsDir = [System.IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($ResultsDir))
+$ModelsDir = [System.IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($ModelsDir))
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Write-Error 'Error: docker is required but was not found in PATH.'
+    exit 1
+}
+
+$composeCommand = $null
+if (& docker compose version *> $null) {
+    $composeCommand = @('docker', 'compose')
+}
+elseif (Get-Command docker-compose -ErrorAction SilentlyContinue) {
+    $composeCommand = @('docker-compose')
+}
+else {
+    Write-Error 'Error: docker compose plugin or docker-compose binary is required.'
+    exit 1
+}
+
+if (-not (Test-Path -Path $ComposeFile -PathType Leaf)) {
+    Write-Error "Error: docker compose file '$ComposeFile' not found."
+    exit 1
+}
+
+[System.IO.Directory]::CreateDirectory($MongoDataDir) | Out-Null
+[System.IO.Directory]::CreateDirectory($MongoLogDir) | Out-Null
+[System.IO.Directory]::CreateDirectory($ResultsDir) | Out-Null
+[System.IO.Directory]::CreateDirectory($ModelsDir) | Out-Null
+
+Write-Host "Using docker compose file: $ComposeFile"
+Write-Host "Project name: $ProjectName"
+Write-Host "MongoDB container: $MongoContainerName (port $MongoPort)"
+Write-Host "API container: $ApiContainerName (ports $ApiPort/$PredictionPort)"
+Write-Host "Node service container: $WebServiceContainerName (port $WebServicePort)"
+Write-Host "Web UI container: $WebUiContainerName (port $WebUiPort)"
+
+if (-not $ComposeArgs -or $ComposeArgs.Count -eq 0) {
+    $ComposeArgs = @('--build', '-d')
+}
+
+$previousEnv = @{}
+$envKeys = @(
+    'COMPOSE_FILE','COMPOSE_PROJECT_NAME','MONGO_CONTAINER_NAME','MONGO_PORT',
+    'MONGO_DATA_DIR','MONGO_LOG_DIR','MONGO_ROOT_USER','MONGO_INITDB_ROOT_USERNAME','MONGO_ROOT_PASSWORD','MONGO_INITDB_ROOT_PASSWORD',
+    'MONGO_APP_DB','MONGO_APP_USER','MONGO_APP_PASSWORD','API_CONTAINER_NAME',
+    'API_PORT','PREDICTION_PORT','HOST_RESULTS_DIR','HOST_MODELS_DIR',
+    'WEB_SERVICE_CONTAINER_NAME','WEB_SERVICE_PORT','WEB_UI_CONTAINER_NAME','WEB_UI_PORT'
+)
+
+foreach ($key in $envKeys) {
+    $previousEnv[$key] = [Environment]::GetEnvironmentVariable($key, 'Process')
+}
+
+try {
+    $env:COMPOSE_FILE = $ComposeFile
+    $env:COMPOSE_PROJECT_NAME = $ProjectName
+    $env:MONGO_CONTAINER_NAME = $MongoContainerName
+    $env:MONGO_PORT = [string]$MongoPort
+    $env:MONGO_DATA_DIR = $MongoDataDir
+    $env:MONGO_LOG_DIR = $MongoLogDir
+    $env:MONGO_ROOT_USER = $MongoRootUser
+    $env:MONGO_INITDB_ROOT_USERNAME = $MongoRootUser
+    $env:MONGO_ROOT_PASSWORD = $MongoRootPassword
+    $env:MONGO_INITDB_ROOT_PASSWORD = $MongoRootPassword
+    $env:MONGO_APP_DB = $MongoAppDb
+    $env:MONGO_APP_USER = $MongoAppUser
+    $env:MONGO_APP_PASSWORD = $MongoAppPassword
+    $env:API_CONTAINER_NAME = $ApiContainerName
+    $env:API_PORT = [string]$ApiPort
+    $env:PREDICTION_PORT = [string]$PredictionPort
+    $env:HOST_RESULTS_DIR = $ResultsDir
+    $env:HOST_MODELS_DIR = $ModelsDir
+    $env:WEB_SERVICE_CONTAINER_NAME = $WebServiceContainerName
+    $env:WEB_SERVICE_PORT = [string]$WebServicePort
+    $env:WEB_UI_CONTAINER_NAME = $WebUiContainerName
+    $env:WEB_UI_PORT = [string]$WebUiPort
+
+    & $composeCommand up @ComposeArgs
+    Write-Host
+    & $composeCommand ps
+}
+finally {
+    foreach ($key in $envKeys) {
+        if ($null -eq $previousEnv[$key]) {
+            Remove-Item -Path "Env:$key" -ErrorAction SilentlyContinue
+        }
+        else {
+            [Environment]::SetEnvironmentVariable($key, $previousEnv[$key], 'Process')
+        }
+    }
+}
+
+Write-Host
+Write-Host 'Stack is up! Services are reachable at:'
+Write-Host "  FastAPI (sync):        http://localhost:$ApiPort"
+Write-Host "  FastAPI (prediction):  http://localhost:$PredictionPort"
+Write-Host "  Node proxy service:    http://localhost:$WebServicePort"
+Write-Host "  React UI:              http://localhost:$WebUiPort"
+Write-Host "  MongoDB:               mongodb://localhost:$MongoPort"
+Write-Host
+Write-Host "Use '$($composeCommand -join ' ') -p $ProjectName down' to stop the stack."

--- a/scripts/setup_docker_local.sh
+++ b/scripts/setup_docker_local.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# Utility script to launch the Energy Fault Detector stack in Docker.
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: ./scripts/setup_docker_local.sh [options] [-- <docker-compose up args>]
+
+Bootstraps the Energy Fault Detector API, Node service, React UI, and MongoDB
+using Docker Compose. Options allow overriding container names, ports, and
+volume locations. Extra arguments after "--" are forwarded to
+"docker compose up".
+
+Options (environment variables may also be used):
+  -h, --help                      Show this help message and exit
+  --project-name <name>           Docker Compose project name (default: energy-fault-detector)
+  --compose-file <path>           Path to the docker compose file (default: ./docker/docker-compose.local.yml)
+  --mongo-container-name <name>   MongoDB container name (default: energy-fault-detector-mongo)
+  --mongo-port <port>             Host port for MongoDB (default: 27017)
+  --mongo-data-dir <path>         Directory for MongoDB data volume (default: ./.mongodb/data)
+  --mongo-log-dir <path>          Directory for MongoDB log volume (default: ./.mongodb/logs)
+  --mongo-root-user <user>        MongoDB root username (default: efd_root)
+  --mongo-root-password <pass>    MongoDB root password (default: efd_root_password)
+  --mongo-app-db <name>           MongoDB application database (default: energy_fault_detector)
+  --mongo-app-user <user>         MongoDB application username (default: efd_app)
+  --mongo-app-password <pass>     MongoDB application password (default: efd_app_password)
+  --api-container-name <name>     API container name (default: energy-fault-detector-api)
+  --api-port <port>               Host port for the synchronous FastAPI service (default: 8000)
+  --prediction-port <port>        Host port for the asynchronous prediction API (default: 8001)
+  --results-dir <path>            Directory to persist API results (default: ./results)
+  --models-dir <path>             Directory containing trained models (default: ./models)
+  --web-service-container <name>  Node service container name (default: energy-fault-detector-web-service)
+  --web-service-port <port>       Host port for the Node service (default: 4000)
+  --web-ui-container <name>       React UI container name (default: energy-fault-detector-web-ui)
+  --web-ui-port <port>            Host port for the React UI (default: 5173)
+
+Environment overrides:
+  EFD_COMPOSE_PROJECT, EFD_COMPOSE_FILE, MONGO_CONTAINER_NAME, MONGO_PORT,
+  MONGO_DATA_DIR, MONGO_LOG_DIR, MONGO_INITDB_ROOT_USERNAME, MONGO_INITDB_ROOT_PASSWORD,
+  MONGO_APP_DB, MONGO_APP_USER, MONGO_APP_PASSWORD, API_CONTAINER_NAME,
+  API_PORT, PREDICTION_PORT, HOST_RESULTS_DIR, HOST_MODELS_DIR,
+  WEB_SERVICE_CONTAINER_NAME, WEB_SERVICE_PORT,
+  WEB_UI_CONTAINER_NAME, WEB_UI_PORT
+
+Examples:
+  ./scripts/setup_docker_local.sh
+  ./scripts/setup_docker_local.sh --api-port 9000 -- --build --detach
+USAGE
+}
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+PROJECT_NAME=${EFD_COMPOSE_PROJECT:-energy-fault-detector}
+COMPOSE_FILE=${EFD_COMPOSE_FILE:-"${ROOT_DIR}/docker/docker-compose.local.yml"}
+MONGO_CONTAINER_NAME=${MONGO_CONTAINER_NAME:-energy-fault-detector-mongo}
+MONGO_PORT=${MONGO_PORT:-27017}
+MONGO_DATA_DIR=${MONGO_DATA_DIR:-"${ROOT_DIR}/.mongodb/data"}
+MONGO_LOG_DIR=${MONGO_LOG_DIR:-"${ROOT_DIR}/.mongodb/logs"}
+MONGO_ROOT_USER=${MONGO_INITDB_ROOT_USERNAME:-${MONGO_ROOT_USER:-efd_root}}
+MONGO_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD:-${MONGO_ROOT_PASSWORD:-efd_root_password}}
+MONGO_APP_DB=${MONGO_APP_DB:-energy_fault_detector}
+MONGO_APP_USER=${MONGO_APP_USER:-efd_app}
+MONGO_APP_PASSWORD=${MONGO_APP_PASSWORD:-efd_app_password}
+API_CONTAINER_NAME=${API_CONTAINER_NAME:-energy-fault-detector-api}
+API_PORT=${API_PORT:-8000}
+PREDICTION_PORT=${PREDICTION_PORT:-8001}
+HOST_RESULTS_DIR=${HOST_RESULTS_DIR:-"${ROOT_DIR}/results"}
+HOST_MODELS_DIR=${HOST_MODELS_DIR:-"${ROOT_DIR}/models"}
+WEB_SERVICE_CONTAINER_NAME=${WEB_SERVICE_CONTAINER_NAME:-energy-fault-detector-web-service}
+WEB_SERVICE_PORT=${WEB_SERVICE_PORT:-4000}
+WEB_UI_CONTAINER_NAME=${WEB_UI_CONTAINER_NAME:-energy-fault-detector-web-ui}
+WEB_UI_PORT=${WEB_UI_PORT:-5173}
+
+COMPOSE_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --project-name)
+      PROJECT_NAME=$2
+      shift 2
+      ;;
+    --compose-file)
+      COMPOSE_FILE=$2
+      shift 2
+      ;;
+    --mongo-container-name)
+      MONGO_CONTAINER_NAME=$2
+      shift 2
+      ;;
+    --mongo-port)
+      MONGO_PORT=$2
+      shift 2
+      ;;
+    --mongo-data-dir)
+      MONGO_DATA_DIR=$2
+      shift 2
+      ;;
+    --mongo-log-dir)
+      MONGO_LOG_DIR=$2
+      shift 2
+      ;;
+    --mongo-root-user)
+      MONGO_ROOT_USER=$2
+      shift 2
+      ;;
+    --mongo-root-password)
+      MONGO_ROOT_PASSWORD=$2
+      shift 2
+      ;;
+    --mongo-app-db)
+      MONGO_APP_DB=$2
+      shift 2
+      ;;
+    --mongo-app-user)
+      MONGO_APP_USER=$2
+      shift 2
+      ;;
+    --mongo-app-password)
+      MONGO_APP_PASSWORD=$2
+      shift 2
+      ;;
+    --api-container-name)
+      API_CONTAINER_NAME=$2
+      shift 2
+      ;;
+    --api-port)
+      API_PORT=$2
+      shift 2
+      ;;
+    --prediction-port)
+      PREDICTION_PORT=$2
+      shift 2
+      ;;
+    --results-dir)
+      HOST_RESULTS_DIR=$2
+      shift 2
+      ;;
+    --models-dir)
+      HOST_MODELS_DIR=$2
+      shift 2
+      ;;
+    --web-service-container)
+      WEB_SERVICE_CONTAINER_NAME=$2
+      shift 2
+      ;;
+    --web-service-port)
+      WEB_SERVICE_PORT=$2
+      shift 2
+      ;;
+    --web-ui-container)
+      WEB_UI_CONTAINER_NAME=$2
+      shift 2
+      ;;
+    --web-ui-port)
+      WEB_UI_PORT=$2
+      shift 2
+      ;;
+    --)
+      shift
+      COMPOSE_ARGS=("$@")
+      break
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Error: docker is required but was not found in PATH." >&2
+  exit 1
+fi
+
+if docker compose version >/dev/null 2>&1; then
+  DOCKER_COMPOSE_CMD=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  DOCKER_COMPOSE_CMD=(docker-compose)
+else
+  echo "Error: docker compose plugin or docker-compose binary is required." >&2
+  exit 1
+fi
+
+abs_path() {
+  python - "$1" <<'PY'
+import os
+import sys
+print(os.path.abspath(sys.argv[1]))
+PY
+}
+
+COMPOSE_FILE=$(abs_path "${COMPOSE_FILE}")
+MONGO_DATA_DIR=$(abs_path "${MONGO_DATA_DIR}")
+MONGO_LOG_DIR=$(abs_path "${MONGO_LOG_DIR}")
+HOST_RESULTS_DIR=$(abs_path "${HOST_RESULTS_DIR}")
+HOST_MODELS_DIR=$(abs_path "${HOST_MODELS_DIR}")
+
+mkdir -p "${MONGO_DATA_DIR}" "${MONGO_LOG_DIR}" "${HOST_RESULTS_DIR}" "${HOST_MODELS_DIR}"
+
+if [[ ! -f "${COMPOSE_FILE}" ]]; then
+  echo "Error: docker compose file '${COMPOSE_FILE}' not found." >&2
+  exit 1
+fi
+
+echo "Using docker compose file: ${COMPOSE_FILE}"
+echo "Project name: ${PROJECT_NAME}"
+echo "MongoDB container: ${MONGO_CONTAINER_NAME} (port ${MONGO_PORT})"
+echo "API container: ${API_CONTAINER_NAME} (ports ${API_PORT}/${PREDICTION_PORT})"
+echo "Node service container: ${WEB_SERVICE_CONTAINER_NAME} (port ${WEB_SERVICE_PORT})"
+echo "Web UI container: ${WEB_UI_CONTAINER_NAME} (port ${WEB_UI_PORT})"
+
+default_args=(--build -d)
+if [[ ${#COMPOSE_ARGS[@]} -eq 0 ]]; then
+  COMPOSE_ARGS=("${default_args[@]}")
+fi
+
+env \
+  COMPOSE_FILE="${COMPOSE_FILE}" \
+  COMPOSE_PROJECT_NAME="${PROJECT_NAME}" \
+  MONGO_CONTAINER_NAME="${MONGO_CONTAINER_NAME}" \
+  MONGO_PORT="${MONGO_PORT}" \
+  MONGO_DATA_DIR="${MONGO_DATA_DIR}" \
+  MONGO_LOG_DIR="${MONGO_LOG_DIR}" \
+  MONGO_ROOT_USER="${MONGO_ROOT_USER}" \
+  MONGO_INITDB_ROOT_USERNAME="${MONGO_ROOT_USER}" \
+  MONGO_ROOT_PASSWORD="${MONGO_ROOT_PASSWORD}" \
+  MONGO_INITDB_ROOT_PASSWORD="${MONGO_ROOT_PASSWORD}" \
+  MONGO_APP_DB="${MONGO_APP_DB}" \
+  MONGO_APP_USER="${MONGO_APP_USER}" \
+  MONGO_APP_PASSWORD="${MONGO_APP_PASSWORD}" \
+  API_CONTAINER_NAME="${API_CONTAINER_NAME}" \
+  API_PORT="${API_PORT}" \
+  PREDICTION_PORT="${PREDICTION_PORT}" \
+  HOST_RESULTS_DIR="${HOST_RESULTS_DIR}" \
+  HOST_MODELS_DIR="${HOST_MODELS_DIR}" \
+  WEB_SERVICE_CONTAINER_NAME="${WEB_SERVICE_CONTAINER_NAME}" \
+  WEB_SERVICE_PORT="${WEB_SERVICE_PORT}" \
+  WEB_UI_CONTAINER_NAME="${WEB_UI_CONTAINER_NAME}" \
+  WEB_UI_PORT="${WEB_UI_PORT}" \
+  "${DOCKER_COMPOSE_CMD[@]}" up "${COMPOSE_ARGS[@]}"
+
+echo
+env \
+  COMPOSE_FILE="${COMPOSE_FILE}" \
+  COMPOSE_PROJECT_NAME="${PROJECT_NAME}" \
+  "${DOCKER_COMPOSE_CMD[@]}" ps
+
+echo
+cat <<INFO
+Stack is up! Services are reachable at:
+  FastAPI (sync):        http://localhost:${API_PORT}
+  FastAPI (prediction):  http://localhost:${PREDICTION_PORT}
+  Node proxy service:    http://localhost:${WEB_SERVICE_PORT}
+  React UI:              http://localhost:${WEB_UI_PORT}
+  MongoDB:               mongodb://localhost:${MONGO_PORT}
+
+Use "${DOCKER_COMPOSE_CMD[*]} -p ${PROJECT_NAME} down" to stop the stack.
+INFO

--- a/web-service/Dockerfile
+++ b/web-service/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1.5
+
+FROM node:20-alpine AS base
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install --omit=dev
+
+COPY . .
+
+ENV NODE_ENV=production
+EXPOSE 4000
+
+CMD ["node", "src/index.js"]

--- a/web-ui/Dockerfile
+++ b/web-ui/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1.5
+
+FROM node:20-alpine AS base
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]


### PR DESCRIPTION
## Summary
- add Dockerfiles and a docker-compose definition to run the API, Node proxy, React UI, and MongoDB locally
- provide Bash and PowerShell helper scripts to bootstrap the stack with configurable ports, container names, and volumes
- document the workflow in the README and add a .dockerignore to streamline image builds

## Testing
- ./scripts/setup_docker_local.sh --help


------
https://chatgpt.com/codex/tasks/task_e_68f87cb4d29c8326b461029eda876291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local Docker development environment with automated setup scripts for Linux/Mac and Windows.

* **Documentation**
  * Added guide for running the full application stack locally using Docker Compose, including service details and configuration options.

* **Chores**
  * Added Docker containerization files and MongoDB initialization scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->